### PR TITLE
fix issue with ACF type Gallery

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -190,6 +190,7 @@ if (!class_exists('WPGraphQLGutenbergACF')) {
                     }
 
                     return array_map(function ($id) use (&$context, &$resolve) {
+                        $id = $id['ID'];
                         return $resolve($id, $context);
                     }, $value);
                 } else {
@@ -754,7 +755,7 @@ if (!class_exists('WPGraphQLGutenbergACF')) {
             $acf_fields = array_merge(
                 [],
                 ...array_map(function (&$field_group) {
-                    return acf_get_fields($field_group['ID']);
+                    return acf_get_fields($field_group['key']);
                 }, $field_groups)
             );
 


### PR DESCRIPTION
Hi, I found some issue when creating ACF field type gallery to Gutenberg Block
when in Graphiql instead of array of MediaItem it return a single MediaItem
the problem appear because the ACF field is created from exported ACF PHP script and there's no `ID` from PHP script
Solved this using `key` in ACF array